### PR TITLE
Corrected Issue with Opening Recent Entries

### DIFF
--- a/main.py
+++ b/main.py
@@ -329,7 +329,7 @@ class Boomslang(wx.Frame):
         Event handler that is called when a recent file is selected
         for opening
         """
-        self.open_xml_file(self.recent_dict[event.GetId()])
+        self.open_xml_file(self.recent_dict[event.GetInt()])
 
     def on_save(self, event):
         """


### PR DESCRIPTION
Line 332 in main.py issues the command to 'open_xml_file', but does this with event.GetId().
The getId() method gets the id of the event - not the id of the object that created the event.

Hence changed to GetInt(), which gets the id that called the event (in this case the menuitem on recent entries).