### PR TITLE
Fix node display

### DIFF
--- a/boom_xml_editor.py
+++ b/boom_xml_editor.py
@@ -70,12 +70,12 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
         tag_txt = wx.TextCtrl(self, value=object_tag, size=lbl_size)
         single_node_sizer.Add(tag_txt, 0, wx.ALL, 5)
         tag_txt.Bind(wx.EVT_TEXT, partial(
-            self.on_text_change, xml_obj=xml_obj))
+            self.on_tag_change, xml_obj=xml_obj))
         self.widgets.append(tag_txt)
 
         value_txt = wx.TextCtrl(self, value=object_text, style=wx.TE_MULTILINE)
         value_txt.Bind(wx.EVT_TEXT, partial(
-            self.on_text_change, xml_obj=xml_obj))
+            self.on_value_change, xml_obj=xml_obj))
         single_node_sizer.Add(value_txt, 1, wx.ALL|wx.EXPAND, 5)
         self.widgets.append(value_txt)
 
@@ -85,7 +85,7 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
         self.widgets.append(add_node_btn)
 
         self.main_sizer.Add(single_node_sizer, 0, wx.EXPAND, 5)
-
+    
     def clear(self):
         """
         Clears the widgets from the panel in preparation for an update
@@ -106,18 +106,28 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
         self.Layout()
 
 
-
-    def on_text_change(self, event, xml_obj):
+    def on_tag_change(self, event, xml_obj):
         """
-        An event handler that is called when the text changes in the text
+        An event handler that is called when the tag text changes in the text
         control. This will update the passed in xml object to something
         new
         """
-        # BUG: TODO: This method assumed that the event is updating text, rather than tag on an xml object. Silly.
+        #TODO: Figure out how this method can be combined with 'on_value_change'
+        xml_obj.tag = event.GetString()
+        pub.sendMessage('on_change_{}'.format(self.page_id),
+                        event=None)
+    
+    def on_value_change(self, event, xml_obj):
+        """
+        An event handler that is called when the value text changes in the text
+        control. This will update the passed in xml object to something
+        new
+        """
+        #TODO: Figure out how this method can be combined with 'on_tag_change'
         xml_obj.text = event.GetString()
         pub.sendMessage('on_change_{}'.format(self.page_id),
                         event=None)
-
+    
     def on_add_node(self, event):
         """
         Event handler that adds an XML node using pubsub

--- a/boom_xml_editor.py
+++ b/boom_xml_editor.py
@@ -5,6 +5,27 @@ from functools import partial
 from pubsub import pub
 
 
+class boomNodeDisplay(wx.BoxSizer):
+    """
+    A class to display the tag and value of a Node
+    """
+    def __init__(self):
+        super(wx.HORIZONTAL)
+        self.id = wx.ID_ANY
+        self.widgets = []
+        pub.subscribe(self.update_ui, f"ui_updater_{self.id}")
+
+    def update_ui(self, xml_obj):
+        """
+        Update the XML Node based on a change
+        
+        Fundamentally, each XML node is a tag and a Value. It also has a number of attributes, but those are displayed separately.
+
+        """
+        
+        
+        
+
 class XmlEditorPanel(scrolled.ScrolledPanel):
     """
     The panel in the notebook that allows editing of XML element values
@@ -41,34 +62,33 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
 
         if xml_obj is not None:
             lbl_size = (75, 25)
-            for child in xml_obj.getchildren():
-                if child.getchildren():
-                    continue
-                sizer = wx.BoxSizer(wx.HORIZONTAL)
-                tag_txt = wx.StaticText(self, label=child.tag, size=lbl_size)
-                sizer.Add(tag_txt, 0, wx.ALL, 5)
-                self.widgets.append(tag_txt)
+            self.add_single_tag_elements(xml_obj, lbl_size)
 
-                text = child.text if child.text else ''
-
-                value_txt = wx.TextCtrl(self, value=text)
-                value_txt.Bind(wx.EVT_TEXT, partial(self.on_text_change, xml_obj=child))
-                sizer.Add(value_txt, 1, wx.ALL|wx.EXPAND, 5)
-                self.widgets.append(value_txt)
-
+            xml_children = xml_obj.getchildren()
+                                         
+            if xml_children:
+                child_lbl = wx.StaticText(self, label="Children:", size=lbl_size)
+                
+                self.main_sizer.Add(child_lbl)
+                self.widgets.append(child_lbl)
+            
+                for child in xml_children:
+                    sizer = wx.BoxSizer(wx.HORIZONTAL)
+                    text = child.tag
+                    tag_txt = wx.TextCtrl(self, value=text if text else "", size=lbl_size)
+                    sizer.Add(tag_txt, 0, wx.ALL, 5)
+                    
+                    text = child.text if child.text else ''
+                    
+                    value_txt = wx.TextCtrl(self, value=text)
+                    value_txt.Bind(wx.EVT_TEXT, partial(self.on_text_change, xml_obj=child))
+                    sizer.Add(value_txt, 1, wx.ALL|wx.EXPAND, 5)
+                    self.widgets.extend([tag_txt, value_txt])
+                    
                 self.main_sizer.Add(sizer, 0, wx.EXPAND)
-            else:
-                if getattr(xml_obj, 'tag') and getattr(xml_obj, 'text'):
-                    if xml_obj.getchildren() == []:
-                        self.add_single_tag_elements(xml_obj, lbl_size)
 
-                add_node_btn = wx.Button(self, label='Add Node')
-                add_node_btn.Bind(wx.EVT_BUTTON, self.on_add_node)
-                self.main_sizer.Add(add_node_btn, 0, wx.ALL|wx.CENTER, 5)
-                self.widgets.append(add_node_btn)
-
-            self.SetAutoLayout(1)
-            self.SetupScrolling()
+        self.SetAutoLayout(1)
+        self.SetupScrolling()
 
     def add_single_tag_elements(self, xml_obj, lbl_size):
         """
@@ -77,16 +97,26 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
         This function is only called when there should be just one
         tag / value
         """
+        object_tag = xml_obj.tag
+        object_text = xml_obj.text
+        
         sizer = wx.BoxSizer(wx.HORIZONTAL)
-        tag_txt = wx.StaticText(self, label=xml_obj.tag, size=lbl_size)
+        tag_txt = wx.TextCtrl(self, value=object_tag if object_tag else "", size=lbl_size)
         sizer.Add(tag_txt, 0, wx.ALL, 5)
+        tag_txt.Bind(wx.EVT_TEXT, partial(
+            self.on_text_change, xml_obj=xml_obj))
         self.widgets.append(tag_txt)
 
-        value_txt = wx.TextCtrl(self, value=xml_obj.text)
+        value_txt = wx.TextCtrl(self, value=object_text if object_text else "")
         value_txt.Bind(wx.EVT_TEXT, partial(
             self.on_text_change, xml_obj=xml_obj))
         sizer.Add(value_txt, 1, wx.ALL|wx.EXPAND, 5)
         self.widgets.append(value_txt)
+
+        add_node_btn = wx.Button(self, label='Add Node')
+        add_node_btn.Bind(wx.EVT_BUTTON, self.on_add_node)
+        sizer.Add(add_node_btn, 0, wx.ALL|wx.CENTER, 5)
+        self.widgets.append(add_node_btn)
 
         self.main_sizer.Add(sizer, 0, wx.EXPAND)
 
@@ -108,6 +138,7 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
 
         self.widgets = []
         self.Layout()
+
 
     def on_text_change(self, event, xml_obj):
         """

--- a/boom_xml_editor.py
+++ b/boom_xml_editor.py
@@ -4,28 +4,6 @@ import wx.lib.scrolledpanel as scrolled
 from functools import partial
 from pubsub import pub
 
-
-class boomNodeDisplay(wx.BoxSizer):
-    """
-    A class to display the tag and value of a Node
-    """
-    def __init__(self):
-        super(wx.HORIZONTAL)
-        self.id = wx.ID_ANY
-        self.widgets = []
-        pub.subscribe(self.update_ui, f"ui_updater_{self.id}")
-
-    def update_ui(self, xml_obj):
-        """
-        Update the XML Node based on a change
-        
-        Fundamentally, each XML node is a tag and a Value. It also has a number of attributes, but those are displayed separately.
-
-        """
-        
-        
-        
-
 class XmlEditorPanel(scrolled.ScrolledPanel):
     """
     The panel in the notebook that allows editing of XML element values
@@ -56,36 +34,23 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
         self.label_sizer.Add(tag_lbl, 0, wx.ALL, 5)
         self.label_sizer.Add((55, 0))
         self.label_sizer.Add(value_lbl, 0, wx.ALL, 5)
-        self.main_sizer.Add(self.label_sizer)
+        self.main_sizer.Add(self.label_sizer, 0, wx.EXPAND|wx.BOTTOM, 5)
 
         self.widgets.extend([tag_lbl, value_lbl])
-
-        if xml_obj is not None:
-            lbl_size = (75, 25)
-            self.add_single_tag_elements(xml_obj, lbl_size)
-
-            xml_children = xml_obj.getchildren()
-                                         
-            if xml_children:
-                child_lbl = wx.StaticText(self, label="Children:", size=lbl_size)
-                
-                self.main_sizer.Add(child_lbl)
-                self.widgets.append(child_lbl)
+        
+        lbl_size = wx.Size(75, 25)
+        self.add_single_tag_elements(xml_obj, lbl_size)
+        
+        xml_children = xml_obj.getchildren()
+        
+        if xml_children:
+            child_lbl = wx.StaticText(self.main_sizer.GetContainingWindow(), label="Children:", size=lbl_size)
             
-                for child in xml_children:
-                    sizer = wx.BoxSizer(wx.HORIZONTAL)
-                    text = child.tag
-                    tag_txt = wx.TextCtrl(self, value=text if text else "", size=lbl_size)
-                    sizer.Add(tag_txt, 0, wx.ALL, 5)
-                    
-                    text = child.text if child.text else ''
-                    
-                    value_txt = wx.TextCtrl(self, value=text)
-                    value_txt.Bind(wx.EVT_TEXT, partial(self.on_text_change, xml_obj=child))
-                    sizer.Add(value_txt, 1, wx.ALL|wx.EXPAND, 5)
-                    self.widgets.extend([tag_txt, value_txt])
-                    
-                self.main_sizer.Add(sizer, 0, wx.EXPAND)
+            self.main_sizer.Add(child_lbl, 0, wx.BOTTOM|wx.ALIGN_CENTRE, 5)
+            self.widgets.append(child_lbl)
+            
+            for child in xml_children:
+                self.add_single_tag_elements(child, lbl_size)
 
         self.SetAutoLayout(1)
         self.SetupScrolling()
@@ -97,28 +62,29 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
         This function is only called when there should be just one
         tag / value
         """
-        object_tag = xml_obj.tag
-        object_text = xml_obj.text
+        # TODO: The update process for some elements isn't working as expected - especially xml tags. Each tag and text in here should have its own ID and be able to have 'update' called on it.
+        object_tag = xml_obj.tag if xml_obj.tag else ""
+        object_text = xml_obj.text if xml_obj.text else ""
         
-        sizer = wx.BoxSizer(wx.HORIZONTAL)
-        tag_txt = wx.TextCtrl(self, value=object_tag if object_tag else "", size=lbl_size)
-        sizer.Add(tag_txt, 0, wx.ALL, 5)
+        single_node_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        tag_txt = wx.TextCtrl(self, value=object_tag, size=lbl_size)
+        single_node_sizer.Add(tag_txt, 0, wx.ALL, 5)
         tag_txt.Bind(wx.EVT_TEXT, partial(
             self.on_text_change, xml_obj=xml_obj))
         self.widgets.append(tag_txt)
 
-        value_txt = wx.TextCtrl(self, value=object_text if object_text else "")
+        value_txt = wx.TextCtrl(self, value=object_text, style=wx.TE_MULTILINE)
         value_txt.Bind(wx.EVT_TEXT, partial(
             self.on_text_change, xml_obj=xml_obj))
-        sizer.Add(value_txt, 1, wx.ALL|wx.EXPAND, 5)
+        single_node_sizer.Add(value_txt, 1, wx.ALL|wx.EXPAND, 5)
         self.widgets.append(value_txt)
 
         add_node_btn = wx.Button(self, label='Add Node')
         add_node_btn.Bind(wx.EVT_BUTTON, self.on_add_node)
-        sizer.Add(add_node_btn, 0, wx.ALL|wx.CENTER, 5)
+        single_node_sizer.Add(add_node_btn, 0, wx.ALL|wx.CENTER, 5)
         self.widgets.append(add_node_btn)
 
-        self.main_sizer.Add(sizer, 0, wx.EXPAND)
+        self.main_sizer.Add(single_node_sizer, 0, wx.EXPAND, 5)
 
     def clear(self):
         """
@@ -140,12 +106,14 @@ class XmlEditorPanel(scrolled.ScrolledPanel):
         self.Layout()
 
 
+
     def on_text_change(self, event, xml_obj):
         """
         An event handler that is called when the text changes in the text
         control. This will update the passed in xml object to something
         new
         """
+        # BUG: TODO: This method assumed that the event is updating text, rather than tag on an xml object. Silly.
         xml_obj.text = event.GetString()
         pub.sendMessage('on_change_{}'.format(self.page_id),
                         event=None)


### PR DESCRIPTION
Not all that sure on this one. Achieved my aim in that this: 1. Allows tags to be edited as well as Values, 2. Makes a cleaner display for the selected node and its children (not one or the other).
However, I feel like I've made it even more messy (and I didn't do a lot of commenting in my code like I usually do).

I guess these issues are all things that I'll come back to as I go through the whole thing trying to properly understand the MVC principles of wx.